### PR TITLE
Fix bug: setState didn't modify the expanded variable.

### DIFF
--- a/collapsiblecalendarview2/src/main/java/com/shrikanthravi/collapsiblecalendarview/widget/CollapsibleCalendar.java
+++ b/collapsiblecalendarview2/src/main/java/com/shrikanthravi/collapsiblecalendarview/widget/CollapsibleCalendar.java
@@ -111,8 +111,6 @@ public class CollapsibleCalendar extends UICalendar {
                 else{
                     expand(400);
                 }
-                expanded = !expanded;
-
             }
         });
 
@@ -541,6 +539,17 @@ public class CollapsibleCalendar extends UICalendar {
         }
 
         expandIconView.setState(ExpandIconView.LESS,true);
+    }
+
+    @Override
+    public void setState(int state) {
+        super.setState(state);
+        if(state == STATE_COLLAPSED) {
+            expanded = false;
+        }
+        if(state == STATE_EXPANDED) {
+            expanded = true;
+        }
     }
 
     public void select(Day day) {


### PR DESCRIPTION
`
public void onDaySelect() {
	collapsibleCalendar.collapse(400);
}
`
When this code is added into the CalendarListener (to make sure when a user clicks on a date, the calendar collapses back to the week view), the following bug occurs:
When a user clicks on the expand icon, the expanded variable changes to true. Then when collape(400) is called by clicking on a date, the calendar collapses but the collapse method does not change the state of the expanded variable. This makes it that when a user then clicks on the expand icon again, to reopen the month view, nothing happens except that the state of the expanded variable changes to false. The user has to click 2 times on the button to open it again.
This is fixed by modifying the expanded variable everytime the setState() method gets called.

GIF:
https://media.giphy.com/media/31Q7rKoIzXUFpv4yoD/giphy.gif